### PR TITLE
Align window movement with documentation

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -260,6 +260,12 @@ bind = $mainMod, right, movefocus, r
 bind = $mainMod, up, movefocus, u
 bind = $mainMod, down, movefocus, d
 
+# Move window position with mainMod + SHIFT + arrow keys
+bind = $mainMod SHIFT, left, movewindow, l
+bind = $mainMod SHIFT, right, movewindow, r
+bind = $mainMod SHIFT, up, movewindow, u
+bind = $mainMod SHIFT, down, movewindow, d
+
 # Switch workspaces with mainMod + [0-9]
 bind = $mainMod, 1, workspace, 1
 bind = $mainMod, 2, workspace, 2
@@ -300,11 +306,11 @@ bindm = $mainMod, mouse:273, resizewindow
 bindm = $mainMod, Z, movewindow
 bindm = $mainMod, X, resizewindow
 
-# Resize windows
-binde = $mainMod+Shift, Right, resizeactive, 30 0
-binde = $mainMod+Shift, Left, resizeactive, -30 0
-binde = $mainMod+Shift, Up, resizeactive, 0 -30
-binde = $mainMod+Shift, Down, resizeactive, 0 30
+# Resize windows with mainMod + CTRL + arrow keys
+binde = $mainMod+Ctrl, Right, resizeactive, 30 0
+binde = $mainMod+Ctrl, Left, resizeactive, -30 0
+binde = $mainMod+Ctrl, Up, resizeactive, 0 -30
+binde = $mainMod+Ctrl, Down, resizeactive, 0 30
 
 
 # Clipboard


### PR DESCRIPTION
The README states:
```
SUPER + SHIFT + [Arrow Keys]: Move active window
SUPER + CTRL + [Arrow Keys]: Resize active window
```

But the `movewindow` bind was missing, and `resizeactive` used `shift` instead of `ctrl`.
(I've chosen the README as the single source of truth, but this could be easily swapped.
