### PR TITLE
use new gesture system

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -220,8 +220,7 @@ input {
 
 # https://wiki.hyprland.org/Configuring/Variables/#gestures
 gestures {
-    workspace_swipe = true
-    workspace_swipe_fingers = 3
+    gesture = 3, horizontal, workspace
 }
 
 # Example per-device config


### PR DESCRIPTION
> workspace_swipe, workspace_swipe_fingers and workspace_swipe_min_fingers were removed in favor of the new gestures system. - https://wiki.hypr.land/Configuring/Variables/#gestures

I've switched the existing values to the new system to remove the config error.